### PR TITLE
Fix swipe back to home when there is only one page in the drawer.

### DIFF
--- a/app/src/main/java/com/github/gezimos/inkos/ui/AppsFragment.kt
+++ b/app/src/main/java/com/github/gezimos/inkos/ui/AppsFragment.kt
@@ -646,7 +646,6 @@ class AppsFragment : Fragment() {
                                     longSwipeRatio = prefs.longSwipeThresholdRatio,
                                     onVerticalPageMove = { delta ->
                                         try {
-                                            if (totalPages <= 1) return@gestureHelper
                                             if (delta > 0) {
                                                 val newPage = (state.currentPage + delta).coerceAtMost(totalPages - 1)
                                                 if (newPage != state.currentPage) {


### PR DESCRIPTION
When there is only one page in the app drawer, the swipe down gesture won't work.

It seems the line `if (totalPages <= 1) return@gestureHelper` is actually doing nothing and caused this problem.

before:

[Screen_recording_20260518_144827.webm](https://github.com/user-attachments/assets/27d49799-f06e-4c05-9b37-b517beb5ca52)

after

[Screen_recording_20260518_144756.webm](https://github.com/user-attachments/assets/aeeedfca-44d1-4461-9418-9b26d43f09be)